### PR TITLE
Replaced call to MySociety::Config.get

### DIFF
--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -475,7 +475,7 @@ class IncomingMessage < ActiveRecord::Base
     # Add an annotation if the text had to be scrubbed
     if part.body_as_text.scrubbed?
       text += _("\n\n[ {{site_name}} note: The above text was badly encoded, and has had strange characters removed. ]",
-                :site_name => MySociety::Config.get('SITE_NAME', 'Alaveteli'))
+                :site_name => AlaveteliConfiguration.site_name)
     end
     # Fix DOS style linefeeds to Unix style ones (or other later regexps won't work)
     text = text.gsub(/\r\n/, "\n")


### PR DESCRIPTION
MySociety::Config.get was being called in `app/models/incoming_message.rb:478 _convert_part_body_to_text` which caused an exception, as our `lib/configuration.rb` uses a different method to parse a YAML file which references environment variables in ERB.

We should do an upstream PR to remove all references to `MySociety::Config.get` and reliance on the git submodule
